### PR TITLE
先頭のタブを削除すると画面が真っ白になるバグを修正

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Same Time Search",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "default_locale": "en",
   "action": {
     "default_icon": {

--- a/src/components/GroupTabs.tsx
+++ b/src/components/GroupTabs.tsx
@@ -46,10 +46,10 @@ export const GroupTabs = ({ className }: GroupTabsProps): JSX.Element => {
   const removeTab = (index: number) => {
     if (options == null) return;
     removeGroup(index, (newGroups) => {
-      if (index === 0) {
-        setSelected(0);
-      } else {
-        setSelected(index - 1);
+      if (index <= selected) {
+        if (selected !== 0) {
+          setSelected(selected - 1);
+        }
       }
       setOptions({ groups: newGroups });
     });

--- a/src/components/GroupTabs.tsx
+++ b/src/components/GroupTabs.tsx
@@ -46,7 +46,11 @@ export const GroupTabs = ({ className }: GroupTabsProps): JSX.Element => {
   const removeTab = (index: number) => {
     if (options == null) return;
     removeGroup(index, (newGroups) => {
-      setSelected(index - 1);
+      if (index === 0) {
+        setSelected(0);
+      } else {
+        setSelected(index - 1);
+      }
       setOptions({ groups: newGroups });
     });
   };


### PR DESCRIPTION
# 概要

- 複数個のタブがある状態でタブを削除したときの選択タブの変更する部分を修正

