### PR TITLE
formがない検索ページでも検索可能にした

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Same Time Search",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "default_locale": "en",
   "action": {
     "default_icon": {

--- a/src/chrome/content.ts
+++ b/src/chrome/content.ts
@@ -12,12 +12,14 @@ chrome.runtime.onMessage.addListener((message: Message) => {
     new Event("change", { bubbles: true })
   );
 
-  const submitButton = searchSubmitButton(inputAndForm.formElement);
-  if (submitButton == null) {
-    inputAndForm.formElement.submit();
-  } else {
-    // submit buttonがあればsubmitイベントが発火するのでsubmit buttonを使う
-    submitButton.click();
+  if (inputAndForm.formElement != null) {
+    const submitButton = searchSubmitButton(inputAndForm.formElement);
+    if (submitButton == null) {
+      inputAndForm.formElement.submit();
+    } else {
+      // submit buttonがあればsubmitイベントが発火するのでsubmit buttonを使う
+      submitButton.click();
+    }
   }
 });
 

--- a/src/chrome/content.ts
+++ b/src/chrome/content.ts
@@ -11,6 +11,10 @@ chrome.runtime.onMessage.addListener((message: Message) => {
   inputAndForm.inputElement.dispatchEvent(
     new Event("change", { bubbles: true })
   );
+  // loosedrawing.comなどではinputイベントを発火させる必要がある
+  inputAndForm.inputElement.dispatchEvent(
+    new Event("input", { bubbles: true })
+  );
 
   if (inputAndForm.formElement != null) {
     const submitButton = searchSubmitButton(inputAndForm.formElement);

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -6,12 +6,10 @@ export const isInputElement = (
 
 type InputAndForm = {
   inputElement: HTMLInputElement;
-  formElement: HTMLFormElement;
+  formElement: HTMLFormElement | null;
 };
 
-const searchFormByInput = (
-  inputElement: HTMLInputElement
-): InputAndForm | null => {
+const searchFormByInput = (inputElement: HTMLInputElement): InputAndForm => {
   let formElement: HTMLFormElement | null = null;
   let element: HTMLElement = inputElement;
   while (element.parentElement != null) {
@@ -21,7 +19,6 @@ const searchFormByInput = (
     }
     element = element.parentElement;
   }
-  if (formElement == null) return null;
   return { inputElement, formElement };
 };
 
@@ -41,7 +38,7 @@ export const searchInputAndForm = (
     const elementById = document.getElementById(id);
     if (elementById != null && isInputElement(elementById)) {
       const formAndInput = searchFormByInput(elementById);
-      if (formAndInput != null) return formAndInput;
+      return formAndInput;
     }
 
     // classNameから検索
@@ -54,7 +51,7 @@ export const searchInputAndForm = (
     );
     for (const inputElementByClassName of inputElementsByClassName) {
       const formAndInput = searchFormByInput(inputElementByClassName);
-      if (formAndInput != null) return formAndInput;
+      return formAndInput;
     }
   }
 
@@ -62,7 +59,7 @@ export const searchInputAndForm = (
   const inputElements = Array.from(document.getElementsByTagName("input"));
   for (const inputElement of inputElements) {
     const formAndInput = searchFormByInput(inputElement);
-    if (formAndInput != null) return formAndInput;
+    return formAndInput;
   }
 
   return null;

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -32,7 +32,7 @@ export const searchInputAndForm = (
   stringInputElement: string
 ): InputAndForm | null => {
   const htmlInputElement = stringToElement(stringInputElement);
-  if (htmlInputElement != null && !isInputElement(htmlInputElement)) {
+  if (htmlInputElement != null && isInputElement(htmlInputElement)) {
     // idから検索
     const id = htmlInputElement.id;
     const elementById = document.getElementById(id);


### PR DESCRIPTION
# 概要

- 検索ページにformがない場合input要素に検索ワードを入れてchangeイベントとinputイベントを発火させるだけにした
- input要素のidなどでの検索機能のtypoを修正
